### PR TITLE
Allow using Activity instead of FragmentActivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,13 @@ dependencies {
 ```
 The changes should look like [this](https://github.com/aakashns/react-native-dialogs-example/commit/b58086d8fb9ece99f0e678dd8bf0e689a856bd43).
 
-Next, you need to change the `MainActivity` of your app to extends `FragmentActivity` instead of `Activity` (otherwise dialogs will not be rendered), and register `ReactNativeDialogsPackage` : 
+Next, you need to change the `MainActivity` of your app to register `ReactNativeDialogsPackage` :
 ```java
-import android.support.v4.app.FragmentActivity;
 import com.aakashns.reactnativedialogs.ReactNativeDialogsPackage;
 
-public class MainActivity extends FragmentActivity implements DefaultHardwareBackBtnHandler {
+public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
     //...
-  
+
           mReactInstanceManager = ReactInstanceManager.builder()
                 //...
                 .addPackage(new MainReactPackage())
@@ -194,4 +193,3 @@ TODO
 Upcoming Features
 -------
 TODO
-

--- a/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
@@ -1,6 +1,6 @@
 package com.aakashns.reactnativedialogs;
 
-import android.support.v4.app.FragmentActivity;
+import android.app.Activity;
 
 import com.aakashns.reactnativedialogs.modules.DialogAndroid;
 import com.facebook.react.ReactPackage;
@@ -13,10 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ReactNativeDialogsPackage implements ReactPackage {
-    FragmentActivity mActivity;
+    Activity mActivity;
 
-    public ReactNativeDialogsPackage(FragmentActivity fragmentActivity) {
-        mActivity = fragmentActivity;
+    public ReactNativeDialogsPackage(Activity activity) {
+        mActivity = activity;
     }
 
     @Override

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -1,7 +1,7 @@
 package com.aakashns.reactnativedialogs.modules;
 
+import android.app.Activity;
 import android.content.DialogInterface;
-import android.support.v4.app.FragmentActivity;
 import android.view.View;
 
 import com.afollestad.materialdialogs.DialogAction;
@@ -23,13 +23,13 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
         return "DialogAndroid";
     }
 
-    FragmentActivity mActivity;
+    Activity mActivity;
 
     public DialogAndroid(
             ReactApplicationContext reactContext,
-            FragmentActivity fragmentActivity) {
+            Activity activity) {
         super(reactContext);
-        mActivity = fragmentActivity;
+        mActivity = activity;
     }
 
     /* Apply the options to the provided builder */


### PR DESCRIPTION
This removes the need to extend FragmentActivity instead of Activity so it can be used with ReactActivity in react-native 0.18+.

Not sure why there was the need to extend FragmentActivity but I tested my app and everything was still working fine.

Fixes #10
