### PR TITLE
Show dialog on UI thread to avoid crash

### DIFF
--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -284,11 +284,14 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                 }
             });
         }
-
-        if(mDialog != null)
-          mDialog.dismiss();
-        mDialog = mBuilder.build();
-        mDialog.show();
+        mActivity.runOnUiThread(new Runnable() {
+            public void run() {
+                if(mDialog != null)
+                  mDialog.dismiss();
+                mDialog = mBuilder.build();
+                mDialog.show();
+            }
+        });
     }
 
     @ReactMethod


### PR DESCRIPTION
Dialog crashes if not ran on main thread. This ensures showing of dialog is ran within main ui thread