### PR TITLE
fix build error caused by support library 23.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.+'
+    compile 'com.android.support:appcompat-v7:23.1'
     compile 'com.facebook.react:react-native:0.14.+'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
on 23.2 build fails with
No resource found that matches the given name (at 'android:actionModeCloseDrawable' with value '@drawable/abc_ic_ab_back_mtrl_am_alpha').