### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
   "bugs": {
     "url": "https://github.com/aakashns/react-native-dialogs/issues"
   },
-  "homepage": "https://github.com/aakashns/react-native-dialogs#readme",
-  "peerDependencies": {
-    "react-native": ">=0.13.0"
-  }
+  "homepage": "https://github.com/aakashns/react-native-dialogs#readme"
 }


### PR DESCRIPTION
peerDependencies make it impossible to use RC versions of RN. It's generally agreed that they're bad practice and should be removed.