### PR TITLE
Update material-dialogs dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ dependencies {
     compile 'com.facebook.react:react-native:0.20.+'
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.github.afollestad.material-dialogs:commons:8f8ab21' // version 0.8.5.0
+    compile 'com.github.afollestad.material-dialogs:commons:0.8.5.8' // version 0.8.5.8
 }


### PR DESCRIPTION
Update https://github.com/afollestad/material-dialogs to version 0.8.5.8 to fit the Android support library 23.2.0