### PR TITLE
Update DialogAndroid.js

### DIFF
--- a/DialogAndroid.js
+++ b/DialogAndroid.js
@@ -59,6 +59,7 @@ class DialogAndroid {
         var elements = indices.map(ind => (finalOptions.items || [])[ind]);
         if(indices.length === 1 && isNaN(indices[0])){
           indices=[] // the case of empty selection
+          elements=[]
         }
         originalCallback(indices, elements);
       }


### PR DESCRIPTION
In case of empty selection on a dialog with `itemsCallbackMultiChoice`, the `elements` array contains [null] instead of []