### PR TITLE
Cast CharSequence before passing it through the bridge

### DIFF
--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -309,7 +309,7 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                 .adapter(simpleListAdapter, new MaterialDialog.ListCallback() {
                     @Override
                     public void onSelection(MaterialDialog dialog, View itemView, int which, CharSequence text) {
-                        callback.invoke(which, text);
+                        callback.invoke(which, text.toString());
                         if (simple != null) {
                             simple.dismiss();
                         }


### PR DESCRIPTION
I found that automated test with appium always crash the application while normal usage is fine. After looking into crash log, it seems that during automated test the `CharSequence` returned is of type `SpannableString` which cannot be passed through the bridge and crash the application.

This patch casts `CharSequence` to string before passing it through the bridge.