### PR TITLE
Added RTL functionality using Gravity

### DIFF
--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -4,6 +4,7 @@ import android.content.DialogInterface;
 import android.view.View;
 
 import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.GravityEnum;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListAdapter;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListItem;
@@ -90,6 +91,42 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                 case "progressIndeterminateStyle": // true for horizontal, DO NOT USE
                     builder.progressIndeterminateStyle(
                             options.getBoolean("progressIndeterminateStyle"));
+                    break;
+                case "buttonsGravity":
+                    String bg = options.getString("buttonsGravity");
+                    if( bg.equals("start") )
+                        builder.buttonsGravity(GravityEnum.START);
+                    else if( bg.equals("end") )
+                        builder.buttonsGravity(GravityEnum.END);
+                    else
+                        builder.buttonsGravity(GravityEnum.CENTER);
+                    break;
+                case "itemsGravity":
+                    String ig = options.getString("itemsGravity");
+                    if( ig.equals("start") )
+                        builder.itemsGravity(GravityEnum.START);
+                    else if( ig.equals("end") )
+                        builder.itemsGravity(GravityEnum.END);
+                    else
+                        builder.itemsGravity(GravityEnum.CENTER);
+                    break;
+                case "titleGravity":
+                    String tg = options.getString("titleGravity");
+                    if( tg.equals("start") )
+                        builder.titleGravity(GravityEnum.START);
+                    else if( tg.equals("end") )
+                        builder.titleGravity(GravityEnum.END);
+                    else
+                        builder.titleGravity(GravityEnum.CENTER);
+                    break;
+                case "rtl":
+                    if( options.getBoolean("rtl") ) {
+                        builder.titleGravity(GravityEnum.END);
+                        builder.itemsGravity(GravityEnum.END);
+                        builder.contentGravity(GravityEnum.END);
+                        builder.buttonsGravity(GravityEnum.START);
+                        builder.btnStackedGravity(GravityEnum.START);
+                    }
                     break;
                 case "progress":
                     ReadableMap progress = options.getMap("progress");


### PR DESCRIPTION
Added the following options:
1. `titleGravity`: should be one of['start', 'end', 'center']
2. `itemsGravity`: should be one of['start', 'end', 'center']
3. `buttonsGravity`: should be one of['start', 'end', 'center']
everything except 'start' and 'end' are assumed to be 'center'

Also added a simpler RTL option:
- `rtl`: if set to `true`, will set title, items, buttons, content, btnStacked gravities

-----
This dialog box uses `{rtl:true}`

![rtl-true](https://cloud.githubusercontent.com/assets/5062458/21292651/a6b23e1c-c521-11e6-8767-8d12a5a8f80b.jpg)


