### PR TITLE
Remove createJSModules - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
@@ -25,7 +25,7 @@ public class ReactNativeDialogsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new DialogAndroid(reactContext));
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
@@ -25,7 +25,7 @@ public class ReactNativeDialogsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new DialogAndroid(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/ReactNativeDialogsPackage.java
@@ -25,7 +25,7 @@ public class ReactNativeDialogsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new DialogAndroid(reactContext));
     }
 
-    // Depreciated RN 0.47
+    // Deprecated from RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker. This change should be backwards compatible according to my tests.