### PR TITLE
Add widgetColor, titleColor, contentColor and linkColor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The following options are currently supported (value type is `String` unless men
 * [`selectedIndex`](https://github.com/afollestad/material-dialogs#single-choice-list-dialogs) (int) - set the preselected index for Single Choice List
 * [`itemsCallbackMultiChoice`](https://github.com/afollestad/material-dialogs#multi-choice-list-dialogs) (function with 2 arguments : selected indices (array of ints) and selected items (array of strings)
 * [`selectedIndices`](https://github.com/afollestad/material-dialogs#multi-choice-list-dialogs) (array of ints) - set the preselected indices for Multiple Choice List
+* [`widgetColor`](https://github.com/afollestad/material-dialogs#coloring-radio-buttons) - set the color of Radio Buttons and EditText
 * `multiChoiceClearButton` (boolean) - provide a 'Clear' button in Multiple Choice List
 * `autoDismiss` (boolean)
 * [`forceStacking`](https://github.com/afollestad/material-dialogs#stacked-action-buttons) (boolean)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ This library is a thin wrapper over [afollestad/material-dialogs](https://github
 
 The following options are currently supported (value type is `String` unless mentioned otherwise) :
 * [`title`](https://github.com/afollestad/material-dialogs#basic-dialog)
+* [`titleColor`](https://github.com/afollestad/material-dialogs#colors)
 * [`content`](https://github.com/afollestad/material-dialogs#basic-dialog)
+* [`contentColor`](https://github.com/afollestad/material-dialogs#colors)
 * [`positiveText`](https://github.com/afollestad/material-dialogs#basic-dialog)
 * [`positiveColor`](https://github.com/afollestad/material-dialogs#basic-dialog)
 * [`onPositive`](https://github.com/afollestad/material-dialogs#callbacks) (function with no arguments)
@@ -120,6 +122,7 @@ The following options are currently supported (value type is `String` unless men
 * [`itemsCallbackMultiChoice`](https://github.com/afollestad/material-dialogs#multi-choice-list-dialogs) (function with 2 arguments : selected indices (array of ints) and selected items (array of strings)
 * [`selectedIndices`](https://github.com/afollestad/material-dialogs#multi-choice-list-dialogs) (array of ints) - set the preselected indices for Multiple Choice List
 * [`widgetColor`](https://github.com/afollestad/material-dialogs#coloring-radio-buttons) - set the color of Radio Buttons and EditText
+* [`linkColor`](https://github.com/afollestad/material-dialogs#colors)
 * `multiChoiceClearButton` (boolean) - provide a 'Clear' button in Multiple Choice List
 * `autoDismiss` (boolean)
 * [`forceStacking`](https://github.com/afollestad/material-dialogs#stacked-action-buttons) (boolean)

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -66,9 +66,18 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                 case "neutralColor":
                     builder.neutralColor(Color.parseColor(options.getString("neutralColor")));
                     break;
+                case "titleColor":
+                    builder.widgetColor(Color.parseColor(options.getString("titleColor")));
+                    break;  
                 case "widgetColor":
                     builder.widgetColor(Color.parseColor(options.getString("widgetColor")));
                     break;
+                case "linkColor":
+                    builder.widgetColor(Color.parseColor(options.getString("linkColor")));
+                    break;    
+                case "contentColor":
+                    builder.widgetColor(Color.parseColor(options.getString("contentColor")));
+                    break;    
                 case "items":
                     ReadableArray arr = options.getArray("items");
                     String[] items = new String[arr.size()];
@@ -77,6 +86,7 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                     }
                     builder.items(items);
                     break;
+                
                 case "autoDismiss":
                     builder.autoDismiss(options.getBoolean("autoDismiss"));
                     break;

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -67,16 +67,16 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                     builder.neutralColor(Color.parseColor(options.getString("neutralColor")));
                     break;
                 case "titleColor":
-                    builder.widgetColor(Color.parseColor(options.getString("titleColor")));
+                    builder.titleColor(Color.parseColor(options.getString("titleColor")));
                     break;  
                 case "widgetColor":
                     builder.widgetColor(Color.parseColor(options.getString("widgetColor")));
                     break;
                 case "linkColor":
-                    builder.widgetColor(Color.parseColor(options.getString("linkColor")));
+                    builder.linkColor(Color.parseColor(options.getString("linkColor")));
                     break;    
                 case "contentColor":
-                    builder.widgetColor(Color.parseColor(options.getString("contentColor")));
+                    builder.contentColor(Color.parseColor(options.getString("contentColor")));
                     break;    
                 case "items":
                     ReadableArray arr = options.getArray("items");

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -86,7 +86,6 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                     }
                     builder.items(items);
                     break;
-                
                 case "autoDismiss":
                     builder.autoDismiss(options.getBoolean("autoDismiss"));
                     break;

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -66,6 +66,9 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                 case "neutralColor":
                     builder.neutralColor(Color.parseColor(options.getString("neutralColor")));
                     break;
+                case "widgetColor":
+                    builder.widgetColor(Color.parseColor(options.getString("widgetColor")));
+                    break;
                 case "items":
                     ReadableArray arr = options.getArray("items");
                     String[] items = new String[arr.size()];


### PR DESCRIPTION
Allow passing a color to `builder.widgetColor()` in the declaration of dialog params.