### PR TITLE
static methods of alert and dismissCurrent

### DIFF
--- a/DialogAndroid.js
+++ b/DialogAndroid.js
@@ -77,6 +77,17 @@ class DialogAndroid {
   list(options, cb){
     NativeModules.DialogAndroid.list(options, cb)
   }
+  
+  static alert(options) {
+    const dialog = new DialogAndroid();
+    dialog.set(options);
+    dialog.show();
+    return dialog;
+  }
+  
+  static dismissCurrent() {
+    (new DialogAndroid()).dismiss();
+  }
 }
 
 module.exports = DialogAndroid;


### PR DESCRIPTION
This is alternative to documenting how to global dismiss which is implementation detail.

This also adds static method of alert so we dont have to do `const blah = new Dialog(); .set .show`, this is more inline with javascript and also RN Alert module - https://facebook.github.io/react-native/docs/alert.html


Usage is like this:

```
    MaterialDialog.alert({
        content: 'MaterialDialog Downloading no reference...',
        positiveText: null,
        negativeText: null,
        progress: {
            indeterminate: true,
            style: 'horizontal'
        },
        widgetColor: CONFIG.backcolor,
        cancelable: false
    });
    setTimeout(MaterialDialog.dismissCurrent, 5000);
```