### PR TITLE
RN 0.56 compat

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
React Native compiles Android project against SDK 26 by default now, https://github.com/facebook/react-native/releases/tag/v0.56.0

Dependencies need to do the same or compilation breaks. This change compiles & runs with RN 0.56

Closes https://github.com/aakashns/react-native-dialogs/issues/88