### PR TITLE
Update material-dialogs version and fix breaking changes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.afollestad.material-dialogs:commons:0.9.0.1'
+    compile 'com.afollestad.material-dialogs:commons:0.9.6.0'
 }

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.GravityEnum;
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.afollestad.materialdialogs.StackingBehavior;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListAdapter;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListItem;
 import com.facebook.react.bridge.Callback;
@@ -99,8 +100,8 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                     builder.autoDismiss(options.getBoolean("autoDismiss"));
                     break;
                 case "forceStacking":
-                    // should change to StackingBehavior? forceStacking is deprecated?
-                    builder.forceStacking(options.getBoolean("forceStacking"));
+                    builder.stackingBehavior(
+                        options.getBoolean("forceStacking") ? StackingBehavior.ALWAYS : StackingBehavior.ADAPTIVE);
                     break;
                 case "alwaysCallSingleChoiceCallback":
                     if (options.getBoolean("alwaysCallSingleChoiceCallback")) {
@@ -399,7 +400,7 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
     public void list(ReadableMap options, final Callback callback) {
         final MaterialSimpleListAdapter simpleListAdapter = new MaterialSimpleListAdapter(new MaterialSimpleListAdapter.Callback() {
             @Override
-            public void onMaterialListItemSelected(int index, MaterialSimpleListItem item) {
+            public void onMaterialListItemSelected(MaterialDialog dialog, int index, MaterialSimpleListItem item) {
                 if (!mCallbackConsumed) {
                     mCallbackConsumed = true;
                     callback.invoke(index, item.getContent());


### PR DESCRIPTION
I had some issues with `com.afollestad.material-dialogs` when using the latest version of app compat libs. Updating it fixed the issue. The was a few breaking changes I had to fix.

- `forceStacking ` was removed, use `StackingBehavior` instead.
- `onMaterialListItemSelected` has an extra parameter.