### PR TITLE
Fixed anonymous class implementation

### DIFF
--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -464,7 +464,7 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
     public void list(ReadableMap options, final Callback callback) {
         final MaterialSimpleListAdapter simpleListAdapter = new MaterialSimpleListAdapter(new MaterialSimpleListAdapter.Callback() {
             @Override
-            public void onMaterialListItemSelected(MaterialDialog dialog, int index, MaterialSimpleListItem item) {
+            public void onMaterialListItemSelected(int index, MaterialSimpleListItem item) {
                 if (!mCallbackConsumed) {
                     mCallbackConsumed = true;
                     callback.invoke(index, item.getContent());


### PR DESCRIPTION
Fixed the method implementation of `onMaterialListItemSelected` implemented as per the `MaterialSimpleListAdapter.Callback` interface. It was failing to compile for me once I updated Android Studio to `v3.3.1`.