### PR TITLE
Revert "Fixed anonymous class implementation"

### DIFF
--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -464,7 +464,7 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
     public void list(ReadableMap options, final Callback callback) {
         final MaterialSimpleListAdapter simpleListAdapter = new MaterialSimpleListAdapter(new MaterialSimpleListAdapter.Callback() {
             @Override
-            public void onMaterialListItemSelected(int index, MaterialSimpleListItem item) {
+            public void onMaterialListItemSelected(MaterialDialog dialog, int index, MaterialSimpleListItem item) {
                 if (!mCallbackConsumed) {
                     mCallbackConsumed = true;
                     callback.invoke(index, item.getContent());


### PR DESCRIPTION
Reverts aakashns/react-native-dialogs#109

This was a non-issue and was to do with my gradle cache... my "fix" stopped working all of a sudden and I realised it was the gradle cache using an older version of the `com.afollestad.material-dialogs` package which I see was version bumped here 22 days ago. This can be reverted as it'll break compilation.