### PR TITLE
Added option to set dialog background color

### DIFF
--- a/DialogAndroid.js
+++ b/DialogAndroid.js
@@ -24,6 +24,7 @@ type OptionsCommon = {|
     positiveColor?: ColorValue,
     negativeColor?: ColorValue,
     neutralColor?: ColorValue,
+    backgroundColor?: ColorValue,
     cancelable?: boolean,
     linkColor?: ColorValue, // applies if contentIsHtml is true, and there are <a> elements in content string
     forceStacking?: boolean,

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Shows a progress dialog. By default no buttons are shown, and hardware back butt
 >         neutralText?: string,
 >         positiveColor?: ColorValue,
 >         positiveText?: string, // default "OK"
+>         backgroundColor?: ColorValue,
 >         title?: string,
 >         titleColor?: ColorValue,
 >     }
@@ -368,6 +369,7 @@ Shows a progress dialog. By default no buttons are shown, and hardware back butt
 | neutralText          | `string`                                                                 |         |          | Shows button in far left with this string as label. If falsy, button is not shown.                                                              |
 | positiveColor        | [`ColorValue`](https://facebook.github.io/react-native/docs/colors.html) |         |          |                                                                                                                                                 |
 | positiveText         | `string`                                                                 |         |          | If falsy, button is not shown.                                                                                                                  |
+| backgroundColor      | [`ColorValue`](https://facebook.github.io/react-native/docs/colors.html) |         |          |                                                                                                                                                 |
 | title                | `string`                                                                 |         |          | Title of dialog                                                                                                                                 |
 | titleColor           | [`ColorValue`](https://facebook.github.io/react-native/docs/colors.html) |         |          | Color of title                                                                                                                                  |
 

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -92,6 +92,9 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                 case "contentColor":
                     builder.contentColor(options.getInt("contentColor"));
                     break;
+                case "backgroundColor":
+                    builder.backgroundColor(options.getInt("backgroundColor"));
+                    break;
                 case "items":
                     ReadableArray arr = options.getArray("items");
                     String[] items = new String[arr.size()];


### PR DESCRIPTION
Added `backgroundColor: ColorValue` param to `OptionsCommon`, whitch allows to set background color of the dialog.