### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,9 @@ android {
         versionCode 1
         versionName "1.0"
     }
+    lintOptions{
+        abortOnError false
+    }
 }
 
 repositories {


### PR DESCRIPTION
If having min api version of **21** I cannot build the project when using this library, since upgrading to the latest Android studio, this change fixes that

**Android Studio 3.4.0
classpath 'com.android.tools.build:gradle:3.4.0'**